### PR TITLE
Prase duration fix

### DIFF
--- a/background_scripts/background.js
+++ b/background_scripts/background.js
@@ -39,6 +39,7 @@ async function validKEY(key){
 }
 
 async function fetchData(tabs) {
+	//Batching the ids array into batches of 50 to comply with the youtude API limitations
     const numRuns = Math.ceil(tabs.length / 50) 
 
     const items = []
@@ -54,6 +55,7 @@ async function fetchData(tabs) {
         // Actually fetching the timestamps 
         const currIDS = tabs.slice(start, stop)
         const url = `https://www.googleapis.com/youtube/v3/videos?id=${currIDS.toString()}&part=contentDetails&key=${API_KEY}`
+		//Youtub's API for fetching video info allows for batch processing with CSV
         const result = await fetch(url).then((data) => data.json()).then((json) => json.items).catch((e) => {tabCount.innerText="BORKED"+e; return})
         
         // Adding to list
@@ -95,9 +97,12 @@ async function sort(){
 
 // Convert "PT18M6S" to 1086 (seconds) ISO-8601
 function parseDuration(charset){
+	//this regex will only extract the value for days, hours, minuites, and seconds omitting months and years since the longest youtube
+	//video ever created was 596.5 hourse approx 24 days and as of now youtube has a max video length/size of 12h or 256GB
 	const numRegex = /^P(?:([-+]?\d+)D)?(?:T(?:([-+]?\d+)H)?(?:([-+]?\d+)M)?(?:([-+]?\d+(?:\.\d+)?)S)?)?$/;
 
   	const values = charset.match(numRegex);
+	//map the vlues to their corresponding time unit.
   	const [, days, hours, minutes, seconds] = values.map(Number);
   	let duration = 0;
   	if(!isNaN(days)) duration += days * 86400;

--- a/background_scripts/background.js
+++ b/background_scripts/background.js
@@ -94,19 +94,19 @@ async function sort(){
 }
 
 // Convert "PT18M6S" to 1086 (seconds) ISO-8601
-// Pretty sure there are a bunch of edge cases not handled here
 function parseDuration(charset){
-	const numberPattern = /\d+/g;
-	const nums = charset.match(numberPattern)
+	const numRegex = /^P(?:([-+]?\d+)D)?(?:T(?:([-+]?\d+)H)?(?:([-+]?\d+)M)?(?:([-+]?\d+(?:\.\d+)?)S)?)?$/;
 
-	return calculateDuration(nums, 1, nums.length)
+  	const values = charset.match(numRegex);
+  	const [, days, hours, minutes, seconds] = values.map(Number);
+  	let duration = 0;
+  	if(!isNaN(days)) duration += days * 86400;
+  	if(!isNaN(hours)) duration += hours * 3600;
+  	if(!isNaN(minutes)) duration += minutes * 60;
+  	if(!isNaN(seconds)) duration += seconds;
+  	return duration;
 }
 
-// Calculate duration in seconds. Flexible between 1 and 3 digits in arr.
-function calculateDuration(arr, count, total){
-	if (count == total+1) return 0
-	return arr[count-1] * Math.pow(60, total-count) + calculateDuration(arr, count+1, total)
-}
 
 function compareDuration(a,b){
 	if (b.duration > a.duration) {


### PR DESCRIPTION
Issues with the old duration parsing function:
the function creates an array from the duration string and then converts it into seconds.
for example, the following duration "PT4H25M30S" would be processed as follows:
	- step1: create the array -> [4, 25, 30]
	- step2: convert all the values to seconds and add them together using the recursive function -> result = 4*60² + 25*60¹ + 30*60°
This would only work if the duration is in one of the following formats: "PT--S", "PT--M--S", "PT--H--M--S"
It always considers the last array element the seconds value, the before last element minutes, and so on. 
The following duration would not be correctly parsed:
"P1DT" would give an output of 1 instead of 86400 which would be sorted equal to a video with a duration of 1 second or 1 minute. (example video for this case: https://www.youtube.com/watch?v=q9E4U39BQSg&t )
"PT1H" would give an output of 1 instead of 3600 which would be sorted less than a video with a duration of 2 seconds. (example video for this case: https://www.youtube.com/watch?v=rru2passumI )
"PT1H5M" would give an output of 61 instead of 3900 which would be sorted less than a video with a duration of 5min 5sec.
The proposed solution is to create a regex that extracts the numbers in the following order: [ years, months, days, hours, minutes, seconds] with missing values marked as undefined
and then match it to the duration string. 
For example, matching "PT2H30M" would return the following object ['PT2H30M', undefined,'2', '30', undefined, index: 0, input: 'PT2H30M', groups: undefined] (we only use the element of index 1,2,3,4 which correspond respectively to days, hours, minutes, and seconds.
we can then match each value to its unit and then convert all the values and add them together to get the total duration in seconds.